### PR TITLE
Interactible targets

### DIFF
--- a/jamgame/Assets/HolisticJam/Scenes/Playgrounds/heckert_playground.unity
+++ b/jamgame/Assets/HolisticJam/Scenes/Playgrounds/heckert_playground.unity
@@ -126,6 +126,80 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &228392167
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1418431880549467286, guid: 1ed73b6b7da201011a4a01f1a94e22b0,
+        type: 3}
+      propertyPath: m_Name
+      value: InteractibleBox_10x10x10_01
+      objectReference: {fileID: 0}
+    - target: {fileID: 7434160997185556841, guid: 1ed73b6b7da201011a4a01f1a94e22b0,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7434160997185556841, guid: 1ed73b6b7da201011a4a01f1a94e22b0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7434160997185556841, guid: 1ed73b6b7da201011a4a01f1a94e22b0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7434160997185556841, guid: 1ed73b6b7da201011a4a01f1a94e22b0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 7434160997185556841, guid: 1ed73b6b7da201011a4a01f1a94e22b0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7434160997185556841, guid: 1ed73b6b7da201011a4a01f1a94e22b0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7434160997185556841, guid: 1ed73b6b7da201011a4a01f1a94e22b0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7434160997185556841, guid: 1ed73b6b7da201011a4a01f1a94e22b0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7434160997185556841, guid: 1ed73b6b7da201011a4a01f1a94e22b0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7434160997185556841, guid: 1ed73b6b7da201011a4a01f1a94e22b0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7434160997185556841, guid: 1ed73b6b7da201011a4a01f1a94e22b0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8590694020862943266, guid: 1ed73b6b7da201011a4a01f1a94e22b0,
+        type: 3}
+      propertyPath: _targetObject
+      value: 
+      objectReference: {fileID: 1096778894}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1ed73b6b7da201011a4a01f1a94e22b0, type: 3}
 --- !u!1 &331501088 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 9005220659476430823, guid: 718786357f7585aeda5e8e1d09eb9bbb,
@@ -952,6 +1026,119 @@ Transform:
   m_Father: {fileID: 2114283753834967213}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1096778889
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1096778893}
+  - component: {fileID: 1096778892}
+  - component: {fileID: 1096778891}
+  - component: {fileID: 1096778890}
+  - component: {fileID: 1096778894}
+  m_Layer: 0
+  m_Name: SimpleMessageBomb
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!135 &1096778890
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1096778889}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1096778891
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1096778889}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1096778892
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1096778889}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1096778893
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1096778889}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 5, y: 1, z: 5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1096778894
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1096778889}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8797082a29ce4cd3c893ad67859a90ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _broker: {fileID: 0}
+  _message: Boom!
+  _messageDelay: 5
 --- !u!1001 &1415234628
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/jamgame/Assets/HolisticJam/Scripts/InteractibleObject.cs
+++ b/jamgame/Assets/HolisticJam/Scripts/InteractibleObject.cs
@@ -10,6 +10,8 @@ namespace HolisticJam
         // needs "field:" to be actually accessible in inspector
         [field: SerializeField] public InteractionBroker Broker { get; protected set; }
 
+        [SerializeField] InteractionTarget _targetObject;
+
         [SerializeField] string _triggerEnteredString = "Proximity";
         [SerializeField] float _triggerEnteredDelay = 10f;
         [SerializeField] string _triggerLeftString = "";
@@ -70,6 +72,20 @@ namespace HolisticJam
         void OnPerformInteraction()
         {
             Debug.Log($"{name} performs interaction");
+
+            if (_targetObject == null)
+            {
+                PerformOnSelf();
+            }
+            else
+            {
+                _targetObject.ActivateTargetAction();
+            }
+
+        }
+
+        private void PerformOnSelf()
+        {
             Broker.UISendUpdate("Ooomph. You pushed the block upwards.", true);
             Invoke(nameof(DelayedUIUpdate), _triggerLeftDelay);
             // This is just some dummy action to give some feedback in the playground scene...

--- a/jamgame/Assets/HolisticJam/Scripts/InteractionMessageTarget.cs
+++ b/jamgame/Assets/HolisticJam/Scripts/InteractionMessageTarget.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace HolisticJam
+{
+    public class InteractionMessageTarget : InteractionTarget
+    {
+        [SerializeField] string _message = "Boom!";
+        [SerializeField] float _messageDelay = 5f;
+
+
+        override public bool ActivateTargetAction()
+        {
+            if (_broker == null) return false;
+
+            _broker?.UISendUpdate(_message, true);
+            Invoke(nameof(ClearMessage), _messageDelay);
+            return true;
+        }
+
+        void ClearMessage()
+        {
+            _broker?.UISendUpdate(_message, false);
+        }
+
+    }
+}

--- a/jamgame/Assets/HolisticJam/Scripts/InteractionMessageTarget.cs.meta
+++ b/jamgame/Assets/HolisticJam/Scripts/InteractionMessageTarget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8797082a29ce4cd3c893ad67859a90ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/jamgame/Assets/HolisticJam/Scripts/InteractionTarget.cs
+++ b/jamgame/Assets/HolisticJam/Scripts/InteractionTarget.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace HolisticJam
+{
+    public abstract class InteractionTarget : MonoBehaviour
+    {
+
+        [SerializeField] protected InteractionBroker _broker;
+
+        void Start()
+        {
+            if (_broker == null)
+            {
+                _broker = FindObjectOfType<InteractionBroker>();
+            }
+        }
+
+        public abstract bool ActivateTargetAction();
+    }
+}

--- a/jamgame/Assets/HolisticJam/Scripts/InteractionTarget.cs.meta
+++ b/jamgame/Assets/HolisticJam/Scripts/InteractionTarget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27d0938ebefaf69fca0829284dd5aa72
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Interactible objects can serve as trigger on other objects now.
If there is no other object referenced they will do some action on themselves.
Otherwise `ActivateTargetAction()` is called on the target object, which can practically do anything.

`InteractionMessageTarget`  is a sample for this.

All that is needed for any other action is:
* inherit from `InteractionTarget`
* implement `        override public bool ActivateTargetAction()`
* the base class will automatically grab a reference to the `InteractionBroker` object in the scene which can be used as `_broker`
  * nonetheless, check if it's `null`!

