### PR TITLE
Add script to turn on the light at start, put on player in demo scene

### DIFF
--- a/jamgame/Assets/HolisticJam/Scenes/Playgrounds/heckert_playground.unity
+++ b/jamgame/Assets/HolisticJam/Scenes/Playgrounds/heckert_playground.unity
@@ -5133,6 +5133,29 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a09559f81050540d985372d732d1ed16, type: 3}
+--- !u!1 &487068091 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8275807991154644824, guid: 01f9e35a403e9d326b9e846e5a99a4db,
+    type: 3}
+  m_PrefabInstance: {fileID: 5734631931103721499}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &487068098
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 487068091}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75a7720984c3249918b2e4810e25d325, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _introDelay: 5
+  _light: {fileID: 2114283754330233425}
+  _startLightLevel: 0.1
+  _introFinishedLightLevel: 0.6
+  _lightingDuration: 5
 --- !u!1 &542508511
 GameObject:
   m_ObjectHideFlags: 0

--- a/jamgame/Assets/HolisticJam/Scripts/PlayerGameIntroSequence.cs
+++ b/jamgame/Assets/HolisticJam/Scripts/PlayerGameIntroSequence.cs
@@ -1,0 +1,45 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace HolisticJam
+{
+    public class PlayerGameIntroSequence : MonoBehaviour
+    {
+        [Tooltip("How long to wait until the intro sequence starts")]
+        [SerializeField] float _introDelay = 5f;
+
+
+        [Tooltip("Drop global background light here")]
+        [SerializeField] Light _light;
+
+        [Tooltip("Lightlevels at the start of the game and at the end of the intro sequence")]
+
+        [SerializeField] [Range(0, 1)] float _startLightLevel;
+        [SerializeField] [Range(0, 10)] float _introFinishedLightLevel;
+        [SerializeField] float _lightingDuration;
+
+        float _dimmingLerp = 0f;
+        float _delayTimer = 0f;
+
+        void Start()
+        {
+            _light.intensity = _startLightLevel;
+        }
+
+        void Update()
+        {
+            if (_delayTimer < _introDelay)
+            {
+                _delayTimer += Time.deltaTime;
+                return;
+            }
+
+            if (_dimmingLerp <= 1f)
+            {
+                _dimmingLerp += Time.deltaTime;
+                _light.intensity = Mathf.Lerp(_startLightLevel, _introFinishedLightLevel, _dimmingLerp);
+            }
+        }
+    }
+}

--- a/jamgame/Assets/HolisticJam/Scripts/PlayerGameIntroSequence.cs.meta
+++ b/jamgame/Assets/HolisticJam/Scripts/PlayerGameIntroSequence.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75a7720984c3249918b2e4810e25d325
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
We now have a script for an intro sequence that will start with the scene at a light low level and, after a delay, will turn on the light.